### PR TITLE
Remove optional full path to mocha and istanbul

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "lint": "node_modules/.bin/eslint .",
     "posttest": "npm run lint",
-    "test": "node node_modules/mocha/bin/mocha --recursive --timeout 25000",
-    "coverage": "node node_modules/.bin/istanbul cover _mocha -- --recursive --timeout 25000"
+    "test": "mocha --recursive --timeout 25000",
+    "coverage": "istanbul cover _mocha -- --recursive --timeout 25000"
   },
   "engines": {
     "node": ">=6.10.2",


### PR DESCRIPTION
We can reference binaries directly since `npm` will resolve the full path it for us.